### PR TITLE
Adding spring actuator endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,20 @@
             <version>3.12.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/identifiers/cloud/ws/resolver/api/controllers/HealthApiController.java
+++ b/src/main/java/org/identifiers/cloud/ws/resolver/api/controllers/HealthApiController.java
@@ -2,6 +2,7 @@ package org.identifiers.cloud.ws.resolver.api.controllers;
 
 import org.identifiers.cloud.ws.resolver.api.models.HealthApiModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +18,9 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("healthApi")
+@Deprecated
+@ConditionalOnProperty(value = "management.endpoint.health.enabled",
+        matchIfMissing = true, havingValue = "false")
 public class HealthApiController {
     @Autowired
     private HealthApiModel model;

--- a/src/main/java/org/identifiers/cloud/ws/resolver/api/models/HealthApiModel.java
+++ b/src/main/java/org/identifiers/cloud/ws/resolver/api/models/HealthApiModel.java
@@ -1,5 +1,7 @@
 package org.identifiers.cloud.ws.resolver.api.models;
 
+import org.identifiers.cloud.ws.resolver.api.controllers.HealthApiController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -15,6 +17,8 @@ import java.util.UUID;
  * Health Check API Controller model.
  */
 @Component
+@Deprecated
+@ConditionalOnBean(HealthApiController.class)
 public class HealthApiModel {
     private static String runningSessionId = UUID.randomUUID().toString();
 

--- a/src/main/java/org/identifiers/cloud/ws/resolver/configuration/AuthorizationConfiguration.java
+++ b/src/main/java/org/identifiers/cloud/ws/resolver/configuration/AuthorizationConfiguration.java
@@ -1,0 +1,39 @@
+package org.identifiers.cloud.ws.resolver.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+public class AuthorizationConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Value("${org.identifiers.cloud.ws.resolver.requiredrole}")
+    String requiredRole;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        String aExp = String.format(
+                "isAuthenticated() and principal.claims['realm_access']['roles'].contains('%s')",
+                requiredRole
+        );
+
+        http.authorizeRequests()
+                .antMatchers("/actuator").access(aExp)
+                .antMatchers("/actuator/loggers/**").access(aExp)
+//                .antMatchers("/insightApi/**").permitAll()
+//                .antMatchers(HttpMethod.GET, "/resolveMirId/**").permitAll()
+//                .antMatchers(HttpMethod.GET, "/actuators/health/**").permitAll()
+                .antMatchers(HttpMethod.GET, "/**").permitAll()
+            .and().cors()
+            .and().anonymous()
+            .and()
+                .csrf().disable()
+                .logout().disable()
+                .formLogin().disable()
+                .oauth2ResourceServer().jwt();
+    }
+}

--- a/src/main/java/org/identifiers/cloud/ws/resolver/daemons/indicators/UpdaterRunningIndicator.java
+++ b/src/main/java/org/identifiers/cloud/ws/resolver/daemons/indicators/UpdaterRunningIndicator.java
@@ -1,0 +1,30 @@
+package org.identifiers.cloud.ws.resolver.daemons.indicators;
+
+import org.identifiers.cloud.ws.resolver.daemons.ResolverDataUpdater;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnEnabledHealthIndicator("updater-running")
+public class UpdaterRunningIndicator implements HealthIndicator {
+    @Autowired
+    ResolverDataUpdater resolverDataUpdater;
+
+    /*
+    * Renato:
+    * For now this just checks if the thread is running,
+    * it would also be good to check if the update was successful and change the readiness state of the instance.
+    * But I couldn't make it work, so I will leave it at that until a future version upgrade of the java or spring.
+    */
+
+    @Override
+    public Health health() {
+        if (resolverDataUpdater.isShutdown())
+            return Health.down().build();
+        else
+            return Health.up().build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,3 +30,42 @@ org.identifiers.cloud.ws.resolver.namespaceresolver.institution.home.url=${WS_RE
 org.identifiers.cloud.ws.resolver.namespaceresolver.institution.description=${WS_RESOLVER_CONFIG_NAMESPACE_RESOLVER_INSTITUTION_DESCRIPTION:Identifiers.org Central Registry}
 org.identifiers.cloud.ws.resolver.namespaceresolver.institution.name=${WS_RESOLVER_CONFIG_NAMESPACE_RESOLVER_INSTITUTION_NAME:EMBL-EBI}
 org.identifiers.cloud.ws.resolver.namespaceresolver.recommendation.explanation=${WS_RESOLVER_CONFIG_NAMESPACE_RESOLVER_RECOMMENDATION_EXPLANATION:Namespace resolution to identifiers.org Central Registry}
+
+
+org.identifiers.cloud.ws.resolver.requiredrole=${WS_RESOLVER_CONFIG_BACKEND_REQUIRED_ROLE:chad}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${WS_RESOLVER_CONFIG_BACKEND_SERVICE_JWT_ISSUERURI:http://localkeycloak:8080/auth/realms/scratchpad}
+
+### Spring actuators
+management.endpoints.jmx.exposure.exclude=*
+management.endpoint.loggers.enabled=true
+management.endpoint.health.enabled=true
+management.endpoint.health.show-details=when_authorized
+#management.health.defaults.enabled=false
+#management.health.redis.enabled=true
+#management.health.updater-running.enabled=true
+#management.health.updater-successful.enabled=true
+
+management.endpoints.web.exposure.include=loggers,health
+
+# Deactivations for peace of mind - likely unnecessary
+management.endpoint.auditevents.enabled=false
+management.endpoint.beans.enabled=false
+management.endpoint.caches.enabled=false
+management.endpoint.conditions.enabled=false
+management.endpoint.configprops.enabled=false
+management.endpoint.env.enabled=false
+management.endpoint.flyway.enabled=false
+management.endpoint.httptrace.enabled=false
+management.endpoint.info.enabled=false
+management.endpoint.integrationgraph.enabled=false
+management.endpoint.liquibase.enabled=false
+management.endpoint.metrics.enabled=false
+management.endpoint.mappings.enabled=false
+management.endpoint.scheduledtasks.enabled=false
+management.endpoint.sessions.enabled=false
+management.endpoint.shutdown.enabled=false
+management.endpoint.threaddump.enabled=false
+management.endpoint.heapdump.enabled=false
+management.endpoint.jolokia.enabled=false
+management.endpoint.logfile.enabled=false
+management.endpoint.prometheus.enabled=false


### PR DESCRIPTION
Replaced legacy health checkers for spring endpoint health check with custom indicators for the thread; Loggers endpoint enabled for production debug when needed; Added spring security for only authenticated users to access loggers actuator
